### PR TITLE
Some fixes to EBNF

### DIFF
--- a/pop11_grammar_ebnf.txt
+++ b/pop11_grammar_ebnf.txt
@@ -35,12 +35,12 @@ Variable ::=
 	| 'nonsyntax' SyntaxWord
 
 Declaration ::=
-	'global'? ('vars' 'procedure'? | 'constant') Varslist ';'
-	| 'lvars' 'procedure'? (',' | Word)+ ';'
+	'global'? ('vars' | 'constant') Varslist ';'
+	| 'lvars' (',' | Word)+ ';'
 	| 'dlocal' (',' | Word)+ ';'
 
 Varslist ::=
-	(','* ('macro' | 'syntax' | Number)? Word)+
+	(','* ('procedure' | 'macro' | 'syntax' | Number)? Word)+
 
 Sequence ::=
 	(Expression (',' | ';' | '=>' | '==>'))+

--- a/pop11_grammar_ebnf.txt
+++ b/pop11_grammar_ebnf.txt
@@ -19,6 +19,7 @@ Expression ::=
 ConstantExpression ::=
 	Construct
 	| '"' Word '"'
+	| '"' String '"'
 
 Definition ::=
 	'define' Word ('(' Varslist? ')' | Varslist)? ('->' Varslist)* ';' Sequence 'enddefine'
@@ -34,10 +35,12 @@ Variable ::=
 	| 'nonsyntax' SyntaxWord
 
 Declaration ::=
-	('global'? ('vars' 'procedure'? | 'constant') Varslist | ('lvars' | 'lconstant' | 'dlocal') (',' | Word)+) ';'
+	'global'? ('vars' 'procedure'? | 'constant') Varslist ';'
+	| 'lvars' 'procedure'? (',' | Word)+ ';'
+	| 'dlocal' (',' | Word)+ ';'
 
 Varslist ::=
-	((','* Word?)+ ('macro' | 'syntax' | Number) Word)+
+	(','* ('macro' | 'syntax' | Number)? Word)+
 
 Sequence ::=
 	(Expression (',' | ';' | '=>' | '==>'))+
@@ -45,7 +48,6 @@ Sequence ::=
 Literal ::=
 	Number
 	| String
-	| '"' String '"'
 
 Construct ::=
 	ListConstruct

--- a/pop11_grammar_ebnf.txt
+++ b/pop11_grammar_ebnf.txt
@@ -2,6 +2,7 @@ Grammar ::= Expression
 
 Expression ::= 
 	Literal
+	| ConstantExpression
 	| Variable
 	| Assignment
 	| Definition
@@ -14,6 +15,10 @@ Expression ::=
 	| Jump
 	| Label
 	| '(' Sequence ')'
+
+ConstantExpression ::=
+	Construct
+	| '"' Word '"'
 
 Definition ::=
 	'define' Word ('(' Varslist? ')' | Varslist)? ('->' Varslist)* ';' Sequence 'enddefine'
@@ -29,7 +34,7 @@ Variable ::=
 	| 'nonsyntax' SyntaxWord
 
 Declaration ::=
-	('global'? ('vars' | 'constant') Varslist | 'lvars' (',' | Word)+) ';'
+	('global'? ('vars' 'procedure'? | 'constant') Varslist | ('lvars' | 'lconstant' | 'dlocal') (',' | Word)+) ';'
 
 Varslist ::=
 	((','* Word?)+ ('macro' | 'syntax' | Number) Word)+
@@ -40,8 +45,7 @@ Sequence ::=
 Literal ::=
 	Number
 	| String
-	| '"' Word '"'
-	| Construct
+	| '"' String '"'
 
 Construct ::=
 	ListConstruct
@@ -71,7 +75,7 @@ PatternSegment ::=
 	| '=='
 
 Label ::=
-	Word ':'
+	Word ':' '*'?
 
 Jump ::=
 	'goto' Word
@@ -81,13 +85,14 @@ Iterative ::=
 	| 'while' Expression 'do' Sequence 'endwhile'
 	| 'until' Expression 'do' Sequence 'enduntil'
 	| 'for' Word (('in' | 'on') | ('from' Expression ('by' Expression)?)? 'to') Expression 'do' Sequence 'endfor'
+	| 'for' Word 'from_repeater' Expression 'do' Sequence 'endfor'
 	| 'foreach' Expression ('in' Expression)? 'do' Sequence 'endforeach'
 	| 'forevery' Expression ('in' Expression)? 'do' Sequence 'endforevery'
 	| 'repeat' (Expression 'times' | 'forever')? Sequence 'endrepeat'
 
 Conditional ::=
-	'if' Expression 'then' Sequence ('elseif' Expression 'then' Sequence)* 'endif'
-	| 'unless' Expression 'then' Sequence ('elseunless' Expression 'then' Sequence)* 'endunless'
+	'if' Expression 'then' Sequence (('elseif' | 'elseunless') Expression 'then' Sequence)* ('else' Expression)? 'endif'
+	| 'unless' Expression 'then' Sequence (('elseif' | 'elseunless') Expression 'then' Sequence)* ('else' Expression)? 'endunless'
 
 BooleanExpression ::=
 	Expression (('and' | 'or') Expression)*
@@ -96,5 +101,5 @@ OperatorExpression ::=
 	Expression Operator Expression
 
 FunctionApplication ::=
-	Expression '(' (Expression (',' Expression)*)? ')'
+	Expression '(' Expression? (',' Expression?)* ')'
 	| '.' Expression


### PR DESCRIPTION
Hi @sfkleach,

I have some doubts that I would like to discuss with you regarding the issues you found on the EBNF grammar.I understand that maybe the differences found are due to the fact that the book's diagrams are old or even wrong, but since I don't know the Pop-11 language I tried to make the EBNF grammar as faithful as possible to the provided charts from the book.

1. **Varslist**

The rail-road diagram from the book for Varslist allows the following input string:
`, word word , , word macro word , , word word syntax word`

So the production you suggest is not correct as far as I can tell, because it allows the input string: `word`
but it shouldn't according to the book's chart. Among other things, all inputs should end with the following pattern:
`(macro | syntax | number) word`.

`Book_Varslist         ::= ( ','* ( 'macro' | 'syntax' | Number )? Word )+`

So according to the book my original production is correct:

`Varslist ::= ( ( ','* Word? )+ ( 'macro' | 'syntax' | Number ) Word )+  `
 
2. **Repeater Iteration**

The `from_repeater` is a terminal? I don't see it in the chart you show in the Google Doc with the feedback. So I'm not sure if it is a terminal or a non terminal.

3. **ListSegment**

I don't know how to Fix all occurrences of Literal appropriately because I don't know where the newly added ConstantExpression nonterminal should be used instead of the original Literal nonterminal. Should I add ConstantExpression as an alternative in Expression?

4. **Declaration**

I can see in the examples you mentioned that declarations can be initialized, but the book's charts don't allow this. Only lconstants can be initialized? Where the procedure qualified can be used? I think I need more examples to come up with the right grammar. So far I modified the production like this but not sure if its ok.

```
Declaration ::=
	('global'? ('vars' 'procedure'? | 'constant') Varslist | ('lvars' | 'lconstant' | 'dlocal') (',' | Word)+) ';'
```

Thanks,
Edgar.