### PR TITLE
Add background material from Poplog documentation

### DIFF
--- a/background/popsyntax
+++ b/background/popsyntax
@@ -1,0 +1,1098 @@
+REF POPSYNTAX                                       John Gibson Jan 1996
+
+      COPYRIGHT University of Sussex 1996. All Rights Reserved.
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<                             >>>>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<        POP-11 SYNTAX        >>>>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<                             >>>>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+This file  details the  syntax of  the Pop-11  language, in  terms  of a
+stream of items as produced by  the itemiser. See REF * ITEMISE for  the
+lexical syntax  of  character-stream  input  to  compilation  (i.e.  the
+textual representation of numbers, words, strings, character  constants,
+etc). See REF * POPCOMPILE for a description of the Pop-11 compiler.
+
+         CONTENTS - (Use <ENTER> g to access required sections)
+
+  1   Statement & Expression Sequences
+            ... compilation-stream
+            ... statement-sequence
+            ... statement
+            ... expression-sequence
+
+  2   Expressions
+            ... expression
+            ... empty-expression
+            ... non-empty-expression
+
+  3   Syntax Operator Forms
+      3.1   General
+            ... syntax-operator-form
+      3.2   Procedure Application and Parenthesised Statement Sequence
+            ... (
+      3.3   Postfix Procedure Call
+            ... .
+      3.4   Assignment Arrows
+            ... ->
+            ... ->>
+      3.5   Boolean Expressions
+            ... and
+            ... or
+      3.6   Labelled Expressions
+            ... :
+            ... :*
+      3.7   Identifier or Section Pathname
+            ... $-
+      3.8   Print Arrows
+            ... =>
+            ... ==>
+
+  4   Syntax Forms
+      4.1   General
+            ... syntax-form
+      4.2   Conditionals
+            ... if
+            ... unless
+      4.3   Iteration
+            ... while
+            ... until
+            ... repeat
+            ... for
+      4.4   Jumps
+            ... goto
+            ... go_on
+      4.5   Loop Exits
+            ... quitloop
+            ... nextloop
+            ... quitif
+            ... quitunless
+            ... nextif
+            ... nextunless
+      4.6   Procedure Exits
+            ... return
+            ... returnif
+            ... returnunless
+      4.7   Quoted Words and Identifiers
+            ... "
+            ... ident
+      4.8   Matchvars
+            ... =*
+            ... =**
+            ... =?
+            ... =??
+      4.9   Escapes for Active, Syntax and Operator Identifiers
+            ... nonactive
+            ... nonop
+            ... nonsyntax
+      4.10  Counted Statement Sequence
+            ... #|
+      4.11  List and Vector Constructors
+            ... [
+            ... {
+            ... cons_with
+      4.12  Identifier Scope Declarations
+            ... section
+            ... lblock
+      4.13  Identifier Declarations
+            ... lvars
+            ... dlvars
+            ... lconstant
+            ... vars
+            ... constant
+            ... iconstant
+            ... global
+            ... nonglobal
+      4.14  Dynamic Localisation of Variables/Expressions
+            ... dlocal
+      4.15  Procedure Definition
+            ... procedure
+            ... define
+
+
+
+
+
+-----------------------------------
+1  Statement & Expression Sequences
+-----------------------------------
+
+...  compilation-stream
+-----------------------
+
+                   ----------------------
+     --------------| statement-sequence |------ <termin> ---------
+                   ----------------------
+
+
+...  statement-sequence
+-----------------------
+
+                       -------------
+     ------------------| statement |--------------------
+                   |   -------------   |
+                   |                   |
+                   |---<---  ;  ---<---|
+                   |                   |
+                   |---<---  => ---<---|
+                   |                   |
+                   ----<--- ==> ---<----
+
+
+...  statement
+--------------
+
+                   -----------------------
+     --------------| expression-sequence |---------------
+                   -----------------------
+
+
+...  expression-sequence
+------------------------
+
+            ------------------>-----------------
+            |                                  |
+            |          --------------          |
+     ------------------| expression |--------------------
+                  |    --------------    |
+                  |                      |
+                  ----<----  ,  ----<-----
+
+
+
+
+
+--------------
+2  Expressions
+--------------
+
+The word categories referred to by the expression diagram are:
+
+    operator   : A word whose identprops  are N (/= 0),  where N is  the
+                 operator precedence.
+
+    identifier : Any  word  that  is  not  syntax,  syntax  operator  or
+                 operator,  i.e.  whose  identprops  are  not  "syntax",
+                 "syntax N" or N.
+
+A literal is any Poplog object except a word or <termin>.
+
+
+
+...  expression
+---------------
+
+                        --------------------
+     -------------------| empty-expression |------------------------
+     |                  --------------------                       |
+  ---|                                                             |---
+     |                ------------------------                     |
+     -----------------| non-empty-expression |----------------------
+                      ------------------------
+
+
+...  empty-expression
+---------------------
+
+     -------------------------------->--------------------------------
+
+
+...  non-empty-expression
+-------------------------
+
+                              -----------
+     -------------------------| literal |----------------------------
+     |                        -----------                           |
+     |                                                              |
+     |                       --------------                         |
+     |-----------------------| identifier |-------------------------|
+     |                       --------------                         |
+     |                                                              |
+     |      --------------    -------------    --------------       |
+  ---+------| expression |----|  operator |----| expression |-------+---
+     |      --------------    -------------    --------------       |
+     |                                                              |
+     |                   ------------------------                   |
+     |-------------------| syntax-operator-form |-------------------|
+     |                   ------------------------                   |
+     |                                                              |
+     |                       ---------------                        |
+     ------------------------| syntax-form |-------------------------
+                             ---------------
+
+
+
+
+
+------------------------
+3  Syntax Operator Forms
+------------------------
+
+3.1  General
+------------
+The generic form is:
+
+...  syntax-operator-form
+-------------------------
+
+          --------------    -------------------    ----------
+    ------| expression |----| syntax-operator |----|  body  |--------
+          --------------    -------------------    ----------
+
+where syntax-operator is a word whose identprops are "syntax N", N being
+the operator  precedence. body  is dependent  on the  particular  syntax
+operator. Standard syntax operator forms follow.
+
+
+
+3.2  Procedure Application and Parenthesised Statement Sequence
+---------------------------------------------------------------
+
+...  (                                                       (syntax -1)
+------
+
+    This takes two forms, depending on whether the preceding  expression
+    is     empty      or     not.      If     empty,      this      is a
+    parenthesised-statement-sequence.       Otherwise,       it       is
+    procedure-application or partial-application.
+
+    parenthesized-statement-sequence:
+
+    --------------------             ----------------------
+ ---| empty-expression |-- ( --------| statement-sequence |----- ) ---
+    --------------------             ----------------------
+
+    procedure-application or partial-application:
+
+                                     -----------------------
+                               ------| expression-sequence |------
+  ------------------------     |     -----------------------     |
+--| non-empty-expression |- ( -|                                 |- ) --
+  ------------------------     |     -----------------------     |
+                               -- % -| expression-sequence |- % --
+                                     -----------------------
+
+
+
+3.3  Postfix Procedure Call
+---------------------------
+
+...  .                                                        (syntax 1)
+------
+
+         --------------             --------------
+   ------| expression |----  .  ----| expression |--------
+         --------------             --------------
+
+    The result of the second expression is applied after evaluating  the
+    first expression.
+
+
+
+3.4  Assignment Arrows
+----------------------
+
+...  ->                                                      (syntax 11)
+-------
+...  ->>                                                     (syntax 11)
+--------
+
+                         -----  ->  ----
+       --------------    |             |    --------------
+   ----| expression |----|             |----| expression |------
+       --------------    |             |    --------------
+                         -----  ->> ----
+
+    After evaluating the  first expression (and  duplicating its  result
+    for ->>), the second expression is compiled in update mode.
+
+
+
+3.5  Boolean Expressions
+------------------------
+
+...  and                                                      (syntax 9)
+--------
+...  or                                                      (syntax 10)
+-------
+
+                         ----- and -----
+       --------------    |             |    --------------
+   ----| expression |----|             |----| expression |------
+       --------------    |             |    --------------
+                         ----- or  -----
+
+    The second expression  is not  evaluated if the  first evaluates  to
+    false (and) or to true (or).
+
+
+
+3.6  Labelled Expressions
+-------------------------
+
+...  :                                                      (syntax -1)
+------
+...  :*                                                     (syntax -1)
+-------
+
+                            -- :  --
+          --------------    |      |    --------------
+    ------| identifier |----|      |----| expression |--------
+          --------------    |      |    --------------
+                            -- :* --
+
+    If the preceding expression is not an identifier, a mishap  results.
+    No code is produced for the  identifier, instead it becomes a  label
+    for the second expression.
+
+    The :* form is for use with non-local jumps.
+
+
+
+3.7  Identifier or Section Pathname
+-----------------------------------
+
+...  $-                                                      (syntax -1)
+-------
+
+    In this, the preceding expression must be empty or a word.
+
+       ------>-------
+       |            |
+       |  --------  |              --------
+    ------| word |--------- $- ----| word |--------
+          --------      |          --------    |
+                        |                      |
+                        -------------<----------
+
+
+
+3.8  Print Arrows
+-----------------
+
+...  =>                                                      (syntax 12)
+-------
+...  ==>                                                     (syntax 12)
+--------
+
+                          -----  =>  ----
+        --------------    |             |
+    ----| expression |----|             |----
+        --------------    |             |
+                          -----  ==> ----
+
+    These are special syntax operators in the sense that after producing
+    the appropriate printing  code they replace  themselves on  proglist
+    with ;, thus terminating the current expression-sequence.
+
+
+
+
+
+---------------
+4  Syntax Forms
+---------------
+
+4.1  General
+------------
+The generic form is:
+
+...  syntax-form
+----------------
+
+           ------------------    ------------
+     ------|  syntax-opener |----|   body   |--------
+           ------------------    ------------
+
+where syntax-opener is a word  whose identprops are "syntax", AND  whose
+valof is a procedure. body is dependent on the particular syntax opener.
+Standard syntax forms follow.
+
+
+
+4.2  Conditionals
+-----------------
+
+...  if                                                         (syntax)
+-------
+...  unless                                                     (syntax)
+-----------
+
+  ---- if -----
+              |   --------------            -----------------
+              |---| expression |--- then ---| statement-seq |-----
+              |   --------------            -----------------    |
+  -- unless ---                                                  |
+                                                                 |
+  --------------------------------<-------------------------------
+  |
+  |   ---- elseif -----
+  |   |               |   --------------            -----------------
+  |->-|               |---| expression |--- then ---| statement-seq |---
+  |   |               |   --------------            -----------------  |
+  |   -- elseunless ---                                                |
+  |                                                                    |
+  |-------------------------------<-------------------------------------
+  |
+  |            -----------------
+  |->- else ---| statement-seq |----
+  |            -----------------   |
+  |                                |
+  |----------------<----------------
+  |
+  |   ----- endif -----
+  |   |
+  ----|
+      |
+      --- endunless ---
+
+    The closing syntax word must match the opener.
+
+
+
+4.3  Iteration
+--------------
+
+...  while                                                      (syntax)
+----------
+...  until                                                      (syntax)
+----------
+
+ - while ---                                               - endwhile -
+           |   --------------          -----------------   |
+           |---| expression |--- do ---| statement-seq |---|
+           |   --------------          -----------------   |
+ - until ---                                               - enduntil -
+
+    The closing syntax word must match the opener.
+
+
+
+...  repeat                                                     (syntax)
+-----------
+
+            -------------->--------------
+            |                           |
+            | --------------            | -----------------
+ - repeat ----| expression |-- times -----| statement-seq |- endrepeat-
+              --------------              -----------------
+
+
+
+...  for                                                        (syntax)
+--------
+
+            --------          --------          --------
+     -------| expr |-- step --| expr |-- till --| expr |------------
+     |      --------          --------          --------           |
+     |                                                             |
+for -|                                                             |
+     |                                                             |
+     |  --------------                                             |
+     ---| identifier |----                                         |
+        --------------   |                                         |
+                         |                                         |
+        ---------<--------                                         |
+        |                                                          |
+        |              --------                                    |
+        |   --- in ----| expr |------------------------------------|
+        |   |          --------                                    |
+        |   |                                                      |----
+        |   |          --------                                    |   |
+        |   |-- on ----| expr |------------------------------------|   |
+        |   |          --------                                    |   |
+        ----|                                                      |   |
+            |          --------         --------         --------  |   |
+            |-- from --| expr |--- by --| expr |--- to --| expr |--|   |
+            |          -------- |       -------- |       --------  |   |
+            |                   --------->-------|                 |   |
+            |----------------->-------------------                 |   |
+            |                                                      |   |
+            |   ------------------------   -----------             |   |
+            ----| for-subsyntax-opener |---| clauses |--------------   |
+                ------------------------   -----------                 |
+                                                                       |
+                                                                       |
+        ----------------------------<-----------------------------------
+        |
+        |         ----------------------
+        --- do ---| statement-sequence |---- endfor ----
+                  ----------------------
+
+    In the above,  for-subsyntax-opener is a  word whose identprops  are
+    "syntax", and whose valof  is a pair conspair("for",procedure).  The
+    clauses following the opener are  dependent on the particular  form.
+    See  HELP * FOR_FORM  for  a  description  of  the  standard   forms
+    available.
+
+
+
+4.4  Jumps
+----------
+
+...  goto                                                       (syntax)
+---------
+
+                    --------------
+      ---- goto ----| identifier |-----
+                    --------------
+
+
+
+...  go_on                                                      (syntax)
+----------
+
+
+          --------------
+- go_on --| expression |-- to ----
+          --------------         |
+                                 |
+       ---------------------------
+       |
+       |       ----------       ----------------------
+       |    ---| prefix |-- : --| statement-sequence |-- endgo_on ---
+       |    |  ----------       ----------------------
+       |    |
+       -----|
+            |                    ------------->------------
+            |   --------------   |         -------------- |
+            ----| identifier |----- else --| identifier |--- ; ----
+              | -------------- |           --------------
+              --------<---------
+
+    In the first form, the whole statement is generated inside a lexical
+    block.  prefix  should  be  a  word,  which  will  be  defined  as a
+    lexically-scoped macro within the block: this macro has one argument
+    and produces a label (of the form go_on-prefix-arg). Thus
+
+                prefix arg:
+
+    can be used within the statement to label different cases, where arg
+    is an integer or the word default. The form
+
+                goto prefix arg
+
+    can also be  used inside  the statement, including  goto prefix  end
+    (the prefix end label is generated automatically immediately  before
+    the endgo_on).
+
+
+
+4.5  Loop Exits
+---------------
+
+...  quitloop                                                   (syntax)
+-------------
+...  nextloop                                                   (syntax)
+-------------
+...  quitif                                                     (syntax)
+-----------
+...  quitunless                                                 (syntax)
+---------------
+...  nextif                                                     (syntax)
+-----------
+...  nextunless                                                 (syntax)
+---------------
+
+   --- quitloop ---                               -----------
+                  |-------------------------- ( --| integer |-- ) ---
+   --- nextloop ---                     |  |      -----------      |
+                                        |  |                       |
+                                        |  ------------->-----------
+   ---- quitif ----                     |
+                  |                     |
+   -- quitunless -|       --------      |
+                  |-- ( --| expr |- ) ---
+   ---- nextif ---|       --------
+                  |
+   -- nextunless --
+
+    If omitted, integer defaults to 1.
+
+
+
+4.6  Procedure Exits
+--------------------
+
+...  return                                                     (syntax)
+-----------
+
+                            -----------------------
+    --- return -------- ( --| expression-sequence |-- ) ------
+                    |       -----------------------       |
+                    |                                     |
+                    -------------------->------------------
+
+
+...  returnif                                                   (syntax)
+-------------
+...  returnunless                                               (syntax)
+-----------------
+
+
+    ------- returnif ----        --------------
+                        |--- ( --| expression |-- ) --------
+    --- returnunless ----        --------------            |
+                                                           |
+    -------------------------<------------------------------
+    |
+    |           -----------------------
+    ------- ( --| expression-sequence |--- ) ---------------
+       |        -----------------------          |
+       |                                         |
+       --------------------->---------------------
+
+
+
+
+4.7  Quoted Words and Identifiers
+---------------------------------
+
+...  "                                                          (syntax)
+------
+
+                            --------
+                 -----------| word |-----------
+                 |          --------          |
+                 |                            |
+                 |      -----------------     |
+      ----  "  --+------| quoted-string |-----+--  "  ----
+                 |      -----------------     |
+                 |                            |
+                 |            --------------  |
+                 --- ident ---| identifier |---
+                              --------------
+
+    In the last case,  identifier is any  word/pathname for a  permanent
+    identifier, and produces the word-identifier for that identifier.
+
+
+...  ident                                                      (syntax)
+----------
+
+                    --------------
+      ---- ident ---| identifier |----
+                    --------------
+
+    where identifier is  any word declared  as an identifier,  including
+    syntax and operators.
+
+
+
+4.8  Matchvars
+--------------
+
+...  =*                                                         (syntax)
+-------
+...  =**                                                        (syntax)
+--------
+...  =?                                                         (syntax)
+-------
+...  =??                                                        (syntax)
+--------
+
+                   --------------
+                ---| identifier |----
+  --- =?  ----  |  --------------   |
+             |--|                   |---
+  --- =?? ----  |  ---------------  |  |             -----------
+                ---| quoted-word |---  |         ----| integer |-----
+                   ---------------     |         |   -----------    |
+                                       |         |                  |
+  --- =*  ----                         |  - : -  |  --------------  |
+             |-------------------------+--|   |--+--| identifier |--+----
+  --- =** ----                         |  - # -  |  --------------  |  |
+                                       |         |                  |  |
+                                       |         |     --------     |  |
+                                       |         -- % -| expr |- % --  |
+                                       |               --------        |
+                                       |                               |
+                                       ---------------->----------------
+
+    quoted-word is the same as for " above.
+
+
+
+4.9  Escapes for Active, Syntax and Operator Identifiers
+--------------------------------------------------------
+
+...  nonactive                                                  (syntax)
+--------------
+
+                         --------------
+      ---- nonactive ----| identifier |----
+                         --------------
+
+    where identifier is any word declared as an active identifier.
+
+
+...  nonop                                                      (syntax)
+----------
+...  nonsyntax                                                  (syntax)
+--------------
+
+                         ----------------------------
+      ---- nonop --------| operator/syntax-operator |----
+                         ----------------------------
+
+                         -------------------------------
+      ---- nonsyntax ----| syntax-word/syntax-operator |----
+                         -------------------------------
+
+
+
+4.10  Counted Statement Sequence
+--------------------------------
+
+...  #|                                                         (syntax)
+-------
+
+                    ----------------------
+      ----- #| -----| statement-sequence |----- |# -----
+                    ----------------------
+
+    The  difference  between  the  userstack  length  after  and  before
+    statement-sequence (i.e.  after-before)  is pushed  onto  the  stack
+    after statement-sequence.
+
+
+
+4.11  List and Vector Constructors
+----------------------------------
+
+...  [                                                          (syntax)
+------
+...  {                                                          (syntax)
+------
+...  cons_with                                                  (syntax)
+--------------
+
+                              -----------
+                    ----------| literal |-----------
+                    |         -----------          |
+                    |                              |
+                    |         ------------         |
+                    |---------| matchvar |---------|
+                    |         ------------         |
+                    |                              |
+                    |          ----------          |
+    --- [ ---       |--- ^ ----| insert |----------|         --- ] ---
+            |       |          ----------          |         |
+            |-------|                              |---------|
+            |  |    |          ----------          |    |    |
+    --- { ---  |    |--- ^^ ---| insert |----------|    |    --- } ---
+               |    |          ----------          |    |
+               |    |                              |    |
+               |    |         ------------         |    |
+               |    |--- % ---| expr-seq |--- % ---|    |
+               |    |         ------------         |    |
+               |    |                              |    |
+               |    |        ---------------       |    |
+               |    ---------| constructor |--------    |
+               |             ---------------            |
+               |                                        |
+               ---------------------<--------------------
+
+    In the above, literal is any  Pop object except the words "[",  "{",
+    "^", "^^"  or  "%", matchvar  is  any  of the  four  matchvar  forms
+    described above, and constructor is the whole diagram recursively.
+
+    insert is  either  a word,  or  an expression  in  parentheses.  The
+    opening bracket must match the closing bracket.
+
+    For cons_with, vector-constructor is the {...} form of  constructor,
+    and expression must yield a vector constructor procedure:
+
+                       --------------   ----------------------
+      --- cons_with ---| expression |---| vector-constructor |---
+                       --------------   ----------------------
+
+
+
+4.12  Identifier Scope Declarations
+-----------------------------------
+
+...  section                                                    (syntax)
+------------
+
+        ----------------------------->-----------------------------
+        |                                                         |
+        |           -------->--------  ----------->-------------  |
+        |           |               |  |                       |  |
+        | --------  |  ----------   |  |         ----------    |  |
+section---| name |-----| import |-------- => ----| export |---------;---
+          --------   | ----------  |           | ----------  |         |
+                     -------<-------           -------<-------         |
+                                                                       |
+                                                                       |
+         ---------------------------------<-----------------------------
+         |
+         |     ----------------------
+         ------| statement-sequence |---- endsection --
+               ----------------------
+
+    import and export  are words.  name is either  a word  or a  section
+    pathname. If  name  is omitted  (i.e.  ; follows  immediately  after
+    section) then the top-level section popsection is used.
+
+
+...  lblock                                                     (syntax)
+-----------
+
+                    ----------------------
+      --- lblock ---| statement-sequence |--- endlblock ---
+                    ----------------------
+
+
+
+4.13  Identifier Declarations
+-----------------------------
+
+...  lvars                                                      (syntax)
+----------
+...  dlvars                                                     (syntax)
+-----------
+...  lconstant                                                  (syntax)
+--------------
+...  vars                                                       (syntax)
+---------
+...  constant                                                   (syntax)
+-------------
+...  iconstant                                                  (syntax)
+--------------
+...  global                                                     (syntax)
+-----------
+...  nonglobal                                                  (syntax)
+--------------
+
+    The above constructs and dlocal (below) have a similar format, and
+    both use the following diagrams:
+
+    declaration-list:
+
+     ---------------<-----------  ,  ---------------<----------
+     |                                                        |
+     |  --------->---------              --------             |
+     |  |                 |   -----------| spec |-----------  |
+     |  |  -------------  |   |          --------          |  |
+  ---------| attribute |------|                            |----- ; ---
+           -------------      |          --------          |
+                              --- ( -----| spec |----- ) ---
+                                      |  --------  |
+                                      |            |
+                                      --<--- , --<--
+
+    spec:
+
+                      ------------->--------------
+                      |                          |
+           ---------  |          --------------  |
+        ---| thing |-----  =  ---| expression |------
+           ---------             --------------
+
+    Here attribute may  only be  omitted if  a single  spec follows;  if
+    present, it applies either to the  single spec following, or to  all
+    the specs following in parentheses. Each spec is a thing  optionally
+    followed by an initialisation expression.
+
+    Using the above, identifier declarations are then simply
+
+                     ---- lvars ----
+                                   |
+                     --- dlvars ---|
+                                   |
+                     -- lconstant -|
+                                   |    --------------------
+                     ---- vars ----+----| declaration-list |---
+                                   |    --------------------
+                     -- constant --|
+                                   |
+                     -- iconstant -|
+                                   |
+                                   |
+      -- global ---  ---- vars ----|
+    --|           |--|             |
+      - nonglobal -  --- constant --
+
+    where thing is an identifier, and attribute is an identprops value.
+
+    Permissible values for the identprops are:  a number N in the  range
+    -12.7 <=  N  <= 12.7,  one  of  the words  "procedure",  "macro"  or
+    "syntax", or "syntax" followed by a number N (except that only 0  or
+    "procedure" are allowed  for lvars and  dlvars inside a  procedure).
+    identprops defaults to 0 if omitted.
+
+    To declare an active identifier, attribute is
+
+                  ------------->------------  --------->--------
+                  |                        |  |                |
+                  |      ----------------  |  |  ------------  |
+      --- active --- : --| multiplicity |--------|identprops|------
+                         ----------------        ------------
+
+    where multiplicity is an integer in  the range 0 - 255, or  defaults
+    to 1  if absent.  A multiplicity  other than  1 is  allowed only  if
+    identprops is 0 or omitted.
+
+
+
+4.14  Dynamic Localisation of Variables/Expressions
+---------------------------------------------------
+
+...  dlocal                                                     (syntax)
+-----------
+
+    Using the declaration-list diagrams given in Identifier Declarations
+    above, this is just
+
+                         --------------------
+          --- dlocal ----| declaration-list |---
+                         --------------------
+
+    but with the following thing and attribute values:
+
+    For a dynamic local variable, thing is an identifier (obviously  one
+    for a variable, not a constant). In this case, attribute if  present
+    has only only one permissible  value, the word "nonactive"  (meaning
+    that the non-active value of the identifier is to be local).
+
+    For a dynamic local expression, thing has the form
+
+                                 -------------->------------
+                                 |                         |
+                 --------------  |        --------------   |
+        --- % ---| expression |----- , ---| expression |------ % ---
+                 --------------           --------------
+
+    where the first expression  is the access  part, and the  (optional)
+    second expression is the update part; if the second is omitted, then
+    the update part defaults to  being the first expression compiled  in
+    update mode.
+
+    attribute if present  specifies the multiplicity  of the  expression
+    (i.e. how many values  it produces), and must  be an integer in  the
+    range 0 - 255. If omitted, it defaults to 1.
+
+
+
+4.15  Procedure Definition
+--------------------------
+
+...  procedure                                                  (syntax)
+--------------
+...  define                                                     (syntax)
+-----------
+
+            ---------
+-- define --| specs |---
+            ---------  |
+                       |   ----------   -----------   --------
+                       |---| inputs |---| outputs |---| with |--- ; ---
+                       |   ----------   -----------   --------        |
+--- procedure ----------                                              |
+                                                                      |
+                                                                      |
+         ------------------------------<-------------------------------
+         |
+         |                              ----- enddefine -----
+         |    ----------------------    |
+         -----| statement-sequence |----|
+              ----------------------    |
+                                        ----- endprocedure ---
+
+
+    inputs have  two possible  forms;  conventionally, the  second  form
+    without parentheses or commas is used only for macro definitions:
+
+                 --------------->--------------
+                 |       --------------       |
+        --- ( -----------| identifier |----------- ) ---
+                     |   --------------   |
+                     ---<----  ,  ----<----
+
+                 --------------->--------------
+                 |       --------------       |
+           --------------| identifier |------------
+                     |   --------------   |
+                     -----------<----------
+
+
+    outputs may be  empty, ->  followed by  a single  identifier, or  ->
+    followed by a comma-separated list of identifiers in parentheses:
+
+            ---------------->-----------------
+            |             --------------     |
+         --------  ->  ---| identifier |---------
+                          --------------
+
+                               --------------
+         ---  ->  --- ( -------| identifier |------- ) ---
+                           |   --------------   |
+                           ---<----  ,  ----<----
+
+
+    The with clause is:
+
+            ----------------->----------------------
+            |       ----------   -----------       |
+         -----------| with_x |---| literal |-----------
+                |   ----------   -----------   |
+                ----------------<---------------
+
+    where with_x may be either with_nargs or with_props, each  occurring
+    at most  once.  For with_nargs,  literal  must be  an  integer;  for
+    with_props it  may be  any item,  the word  false being  interpreted
+    specially as <false>.
+
+
+    In the define syntax form, specs are:
+
+        ------->--------
+        |              |     ---------------     --------------
+     ----- updaterof --------| declaration |-----| identifier |---
+                             ---------------     --------------
+
+    where declaration declares the procedure name identifier, and can be
+    either
+
+                       ----------->---------
+                       |                   |
+     ----- dlocal --------- nonactive ----------
+
+    or
+
+        ------->-----  ----------->---------  ---------->---------
+        |           |  |  ---------------  |  |  --------------  |
+     ----- global --------| declarator  |--------| identprops |------
+                          ---------------        --------------
+
+    In the  second  form,  declarator  follows the  same  rules  as  for
+    Identifier  Declarations,  i.e.  lvars,  dlvars,  lconstant,   vars,
+    constant, or iconstant,  but vars  or constant only  when global  is
+    present. If declarator is omitted,  the default declaration made  is
+    controlled by the variable popdefineconstant.
+
+    identprops has the  same values as  for Identifier Declarations.  If
+    omitted, it defaults to  "procedure" if popdefineprocedure is  true,
+    or 0 otherwise.
+
+    A special case for the define statement is when identprops  declares
+    an ordinary operator. In this  case, identifier is amalgamated  with
+    the inputs which  would normally  follow it, and  together take  the
+    form
+
+        ------->---------- --------->-------- -------->---------
+        | -------------- | | -------------- | | -------------- |
+     -----| identifier |-----| identifier |-----| identifier |-----
+          --------------     --------------     --------------
+
+    i.e. 1, 2 or 3 occurrences of identifier. The name being defined  is
+    then the first identifier  if 1 or 2  are present (nonary and  unary
+    prefix forms), and the second if 3 are present (binary infix form).
+
+
+
+
+--- C.all/ref/popsyntax
+--- Copyright University of Sussex 1996. All rights reserved.

--- a/background/syswords
+++ b/background/syswords
@@ -1,0 +1,274 @@
+HELP SYSWORDS                             Updated Aaron Sloman, Nov 1986
+
+
+See HELP *HELPFILES for an overview of documentation files.
+
+CONTENTS - (Use <ENTER> g to access sections)
+
+ -- Introduction
+ -- Arithmetic operators
+ -- Logical bitwise operators (all of precedence 4)
+ -- Bitwise comparisons (precedence 6)
+ -- Other non-alphanumeric symbols
+ -- Datawords of built in data-types
+ -- Syntax words and macros
+
+
+-- Introduction -------------------------------------------------------
+
+Non-alphanumeric symbols and operations are listed immediately
+below. They are followed by POP11 SYNTAX words and the words which
+are used as datawords of system objects. E.g.
+
+    dataword(99) = "integer".
+
+Some of the entries have separate HELP or TEACH files, or both.
+Names of HELP files are preceded by asterisks.
+
+Infix operation identifiers are listed with their precedences in
+    HELP *PRECEDENCE
+
+REF *POPSYNTAX gives POP-11 syntax diagrams
+
+
+-- Arithmetic operators ------------------------------------------
+
+See REF *NUMBERS
++       Add one number to another, eg 4 + 5 = 9
+-       Subtract one number from another, eg 5 - 3 = 2
+            if at start of expression is unary minus, eg -5 * 4 = -20
+*       Multiply two numbers, eg 4 * 5 = 20
+**      Raise one number to the power of another, eg 2 ** 3 = 8
+/       Divide one number by another, eg 8 / 4 = 2
+//      Divide one integer by another to get dividend and remainder,
+            eg 10 // 3 -> dividend -> remainder;
+<       Compare two numbers; result true if first smaller
+<=      Compare two numbers; result true if first smaller or equal
+>       Compare two numbers; result true if first greater
+>=      Compare two numbers; result true if first greater or equal
+==#     Compare two items; result true if they are identical (i.e. ==)
+            or numbers of same type and value
+
+
+-- Logical bitwise operators (all of precedence 4) ----------------
+
+&&      Logical 'and' on two integers treated as bitstrings,
+        eg 27 && 22 = 18
+&&~~    Logical 'and_not' on two integers treated as bitstrings
+~~      Logical 'negate' on an integer treated as a bitstring,
+        eg ~~ 5 = 6
+||      Logical 'or' on integers treated as bit strings,
+        eg 27 || 22 = 31
+||/&    Logical exclusive OR on two integers
+<<      Logical 'shift left' on integer as bitstring,
+        eg 12 << 2 = 48
+>>      Logical 'shift right', on integer as bitstring,
+        eg 48 >> 2 = 12
+
+
+-- Bitwise comparisons (precedence 6) ---------------------------------
+
+x &&=_0 y -> <boolean>
+    True if bitwise logical "and" of X and Y is equal to 0
+
+x &&/=_0 y -> <boolean>
+    True if bitwise logical "and" of X and Y is not equal to 0
+
+For more on bitwise operations on integers see REF * NUMBERS
+
+See REF *FASTPROCS for non-type-checking versions of arithmetic and
+logical operators (i.e. fi_+ fi_-, fi_~~, etc.)
+
+
+-- Other non-alphanumeric symbols -------------------------------------
+
+'       String constructor, eg 'string', see *STRINGS and REF ITEMISE
+`       Quote a character, eg `a`, see *ASCII, and REF ITEMISE
+"       Word quote, eg "word", see *WORDS
+%       For unquoting in lists and vectors, see *PERCENT,
+            and for partial application, see *PARTAPPLY
+(       Used in procedure calls, forming expressions etc, see *ROUNDBRA
+)       Closing bracket for '('
+{       Vector constructor, eg {vector}, see  *TWIDDLYBRA
+}       Closing bracket for Vector expressions.
+,       Separates expressions, variables in declarations etc
+-->     Pattern matched assignment, mishap if it fails, see  *MATCHES
+->      Assignment arrow, eg 3 -> X (notice goes left to right)
+->>     Assign and leave on stack, eg 0 ->> X -> Y (sets X and Y to zero)
+.       Infix version of 'apply', eg [a b c].hd = "a"
+/=      Not equal (works recursively on structures)
+/==     Not identical (doesn't work recursively on structures)
+/* ... */
+        Comment brackets
+:       Use after a word to make it a label, see  *GOTO
+::      Create a new list link, eg "a" :: [b c d] = [a b c d]
+            Second argument must be a list (possibly empty)
+;       Separate commands, terminate procedure headers etc
+<>      Concatenate two structures; works on strings, lists, words,
+        vectors, procedures, eg 'abc' <> 'def' = 'abcdef',
+        [a b c] <> [d e f] = [a b c d e f], "abc" <> "def" = "abcdef",
+        {a b c} <> {d e f} = {a b c d e f}
+nc_<>   like <> but on lists does not copy first argument.
+=       Equal (works recursively on structures)
+==      Identical (doesn't recurse on structures)
+==>     Pretty printer for lists and vectors. Does indentation, etc.
+=>      Print Arrow
+><      String concatenator, combines any two printable things to a string,
+            see  *STRINGS.
+dir_><  String concatenator for directory names and file names. Copes
+        with either Unix or VMS formats, depending on operating system.
+?       Match one list element, see  *MATCHES
+??      Match arbitrarily many list elements, see  *MATCHES
+[       List constructor, eg [a list], see  *SQUAREBRA
+]       List closing bracket
+^       Insert value of next word into list or vector, see TEACH *ARROW
+^^      Merge value of next word into list or vector, see TEACH *ARROW
+#_< ... code  >_#
+        execute code at compile time see * HASH_
+#_IF <condition1>
+    <code>
+#_ELSEIF <condition2>
+    <code>
+#_ELSE
+    <code>
+#_ENDIF
+        Used for conditional compilation. Conditions evaluated at compile
+    time.
+
+
+-- Datawords of built in data-types -----------------------------------
+
+biginteger  Dataword of big integers (e.g. 2**99).
+boolean     Dataword of *TRUE and *FALSE
+complex     Dataword of complex numbers
+ddecimal    Dataword of double precision decimals
+decimal     Dataword of singe precision decimals
+device      Dataword of device records
+ident       Dataword of identifiers
+integer     Dataword of integers
+intvec      Dataword of invects - see REF * INTVEC
+key         Dataword of keys, see  *KEYS.
+nil         Dataword of nil i.e. []
+pair        Dataword of pairs, see  *CONSPAIR
+procedure   Dataword of procedures
+process     Dataword of processes, see  *PROCESS
+prologterm  Dataword of Prolog terms
+prologvar   Dataword of prolog vars
+ratio       Dataword of ratios (e.g. 3/4)
+ref         Dataword of items created by CONSREF. Also a macro for using the
+                VED editor to read REFerence files.
+section     Dataword of sections
+string      Dataword for strings
+termin      dataword of *TERMIN
+undef       Dataword of undef objects
+vector      Dataword for vectors
+word        Dataword of words.
+
+
+-- Syntax words and macros --------------------------------------------
+
+active      identprops of active variables
+and         Boolean 'and', combines two booleans, see  *AND
+andcase     See  *SWITCHON
+by          See  *FOR
+case        See  *SWITCHON
+constant    For declaring constant identifiers. See  *CONSTANT.
+cons_with <expression> { ... }
+            For building arbitrary structures.
+constant    identifier declaration
+define      Used for procedure definitions, see  *DEFINE
+dlocal      For declaring dynamic locals. See HELP * DLOCAL
+dlvars      See *DLVARS
+do          A synonym for THEN, see  *UNTIL,  *WHILE, and  *FOR
+else        Used in conditionals, see  *IF
+elseif      See  *IF
+elseunless  See  *IF
+enddefine   End of procedure definition
+endfast_for See REF * FASTPROCS
+endfor      End of a FOR loop, see  *FOR
+endforeach  End of a FOREACH loop, see  *FOREACH
+endforevery End of a FOREVERY loop, see  *FOREVERY
+endform     See *FORMS
+endif       End of an IF statement, see  *IF
+endprefix   End of PREFIX section, see  *PREFIX
+endprocedure End of anonymous procedure, see  *PROCEDURE
+endrecord   Switch off recording, see  *RECORD
+endrepeat   End of a REPEAT loop, see  *REPEAT
+endswitchon End of a SWITCHON, see  *SWITCHON
+endsection  End of a section see *SECTIONS
+endunless   End of an UNLESS statement, see  *UNLESS
+enduntil    End of an UNTIL loop, see  *UNTIL
+endwhile    End of a WHILE loop, see  *WHILE
+fast_for    See REF * FASTPROCS
+for         Start of an iterative loop, see  *FOR
+foreach     Start of a database iteration loop, see  *FOREACH
+forever     Used in REPEAT FOREVER.....ENDREPEAT. Endless iteration.
+forevery    Start of iteration over combinations of database items,
+                see  *FOREVERY
+form        Start of new syntax specification. See *FORMS
+from        Used with FOR, see  *FOR
+global      Used with vars and sections. See *GLOBAL
+go_on <expression> to <labels.....> else <label> ;
+            Computed goto. See  *GO_ON. See  *SWITCH
+goto        Archaic, used to transfer control to a label
+if          Start of conditional statement, see  *IF
+in          Used with FOR, see  *FOR
+lconstant   Used with lexical variables. See HELP * LEXICAL REF *VMCODE
+load        Used to compile files. See *LOAD
+lvars       For lexically scoped local variables. see *LVARS, REF *VMCODE
+macro       Used when declaring or defining macros, see  *MACRO
+nextif(condition)
+            For loop control. Equivalent to:
+            if condition the nextloop endif;
+nextloop    Terminate this iteration and start next, see  *NEXTLOOP
+nextloop(N) Terminate Nth nested iteration and start next, see NEXTLOOP
+nextunless(condition) - see nextif
+nonactive   Can preced an active variable to deactivate it.
+nonmac      Prevents a macro being expanded, see  *NONMAC
+nonop       Prevents an infix procedure being applied, see  *NONOP
+nonsyntax   Preceding a syntax word prevents it being applied.
+notcase     Used with SWITCHON, see  *SWITCHON
+on          Used in FOR loops, see  *FOR
+or          Boolean 'or' on conditions, see  *OR
+prefix      protect variables by preceding them with prefix, see  *PREFIX
+procedure   Introduces anonymous procedure, see  *PROCEDURE
+pwd         Macro to print out current_directory
+quitif(condition)
+            Terminate current iteration if satisfied, see  *QUITIF
+quitif(condition)(N)
+            As QUITIF, but leaves Nth enclosing iteration
+quitloop    Terminate current iteration, see  *QUITLOOP
+quitloop(N) As QUITLOOP but terminates Nth enclosing iteration
+quitunless(condition)
+            As QUITIF except condition must be FALSE to terminate
+record      Switches on recording of terminal interaction, see  *RECORD
+recordclass Macro for defining new structures, see  *RECORDCLASS
+repeat      Start a fixed number of iterations, see  *REPEAT
+return      Jump to end of current procedure, see  *RETURN
+return(item) As above, but leave item on stack.
+section     start a section. See *SECTIONS
+step        Used with FOR, see  *FOR
+switch      Go to one of a number of labels, see  *SWITCH
+switchon    A generalised 'case' facility, see  *SWITCHON
+syntax      Identprops of syntax words, see REF *IDENT
+then        Used with IF and UNLESS
+till        Used with FOR, see  *FOR
+times       Used with REPEAT, see  *REPEAT
+to          Used with FOR, see  *FOR
+trace       used to switch on tracing of procedures
+unless      Start conditional statement, see  *UNLESS
+until       Start iteration, terminated when condition met, see  *UNTIL
+untrace     Switch off tracing of procedures.
+updaterof   Syntax word used with *DEFINE for defining updaters.
+uses        For secretly loading library programs if not already loaded.
+vars        Declare variables, see  *VARS
+vectorclass Macro for defining new classes of vectors. See  *VECTORCLASS
+while       Start iteration, continue while condition met, see  *WHILE
+with_nargs  Use in procedure definition to specify number of arguments
+            See *WITH_NARGS
+with_props  Use in procedure definition to specify initial *PDPROPS
+            See REF *SYNTAX
+
+
+--- C.all/help/syswords
+--- Copyright University of Sussex 1992. All rights reserved. ----------


### PR DESCRIPTION
I have found a railroad-style grammar in the reference section of the Poplog documentation and also a document that lists the reserved words. (As Pop-11 is an extensible language, these are inevitably never truly complete.) 

This pull-request adds these help files to a folder for background information. It is also possible to view these online, thanks to Anthony Worrall's documentation->HTML converter at:

 - [popsyntax](http://www.poplog.cs.reading.ac.uk/popbook/ref/popsyntax.html)
 - [syswords](http://www.poplog.cs.reading.ac.uk/popbook/help/syswords.html)

However I think it makes sense to capture the reference material we used in this repository.