### PR TITLE
Extend makefile to include building the EBNF railroad diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 cython_debug/
 /_build/
 /attic/
+/_buildtools/

--- a/Makefile
+++ b/Makefile
@@ -32,20 +32,40 @@ endif
 .PHONY: help
 help:
 	# Valid targets are:
+	#   setup		One-time setup to poetry install & download *.war
 	#   build       Creates tabatkins grammar & itemisation grammar
 	#	show		Shows the tabatkins grammar in a browser			
 	#	clean		Removes artefacts
+	#   deepclean	In addition to normal cleaning removes tools
 
 .PHONY: show
 show: _build/tabatkins.html
 	$(OPEN) $^
 
+.PHONY: setup
+setup: _buildtools/railroad/rr.war
+	poetry install
+
+_buildtools/railroad/rr.war: _buildtools/railroad/rr-1.67-java8.zip
+	mkdir -p _buildtools/rr
+	( cd _buildtools/railroad; unzip -o ../railroad/rr-1.67-java8.zip )
+	rm -f _buildtools/rr-1.67-java8.zip
+
+_buildtools/railroad/rr-1.67-java8.zip:
+	mkdir -p _buildtools/railroad/
+	curl https://bottlecaps.de/rr/download/rr-1.67-java8.zip > $@
+
+
 .PHONY: clean
 clean:
 	rm -rf _build
 
+.PHONY: deepclean
+deepclean: clean
+	rm -rf _buildtools
+
 .PHONY: build
-build: _build/tabatkins.html _build/itemisation_grammar_ebnf.txt
+build: _build/tabatkins.html _build/itemisation_grammar_ebnf.txt _build/pop11_grammar_ebnf.html
 
 _build/tabatkins.html: tabatkins2html.py pop11_grammar_tabatkins.txt
 	mkdir -p _build
@@ -54,3 +74,7 @@ _build/tabatkins.html: tabatkins2html.py pop11_grammar_tabatkins.txt
 _build/itemisation_grammar_ebnf.txt: itemisation_grammar_ebnf.py
 	mkdir -p _build
 	poetry run python3 itemisation_grammar_ebnf.py > $@
+
+_build/pop11_grammar_ebnf.html: _buildtools/railroad/rr.war
+	mkdir -p _build
+	java -jar _buildtools/railroad/rr.war pop11_grammar_ebnf.txt > $@

--- a/README.md
+++ b/README.md
@@ -3,5 +3,37 @@ This is a work-in-progress. The aim is to provide a couple of formal grammars fo
 The current state of the repo is that the grammars are a hybrid between current Pop-11 and the version of 
 Pop-11 described in Sloman and Barrett "Pop-11: A Practical Language for Artificial Intelligence". 
 
-N.B. Work has been suspended for a while, as the contributors had other issues to attend to. We plan to resume this
-side of Xmas 2022. UPDATE: Work has been resumed :)
+## Building the railroad diagrams 
+
+To visualise the grammars we have added a couple of tools that create
+railroad diagrams. These can be invoked via:
+
+    make build
+
+When this runs it will leave the results in the _build folder. On my
+machine it looks like this:
+
+    % ls -l _build
+    total 292
+    -rw-rw-r-- 1 steve steve  36889 Feb  7 22:57 itemisation_grammar_ebnf.txt
+    -rw-rw-r-- 1 steve steve 128230 Feb  7 22:57 pop11_grammar_ebnf.html
+    -rw-rw-r-- 1 steve steve 126932 Feb  7 22:57 tabatkins.html
+
+## Build Pre-requisites
+
+There are some pre-requisites. I haven't got around to automating these
+as yet, so you need to install them by hand. If you do this, always start
+with `sudo apt update` before continuing:
+
+    1. python3                      sudo apt install python
+    2. poetry                       see https://python-poetry.org/docs/ 
+    3. a JRT (Java run-time)        sudo apt install default-jdk
+    4. curl                         sudo apt install curl
+
+There is also some one-time setup - running poetry install and downloading
+a JAR file to run the EBNF compiler. This can be done with the target
+setup:
+
+    make setup
+
+This will install the JAR file into the _buildtools folder.


### PR DESCRIPTION
This PR extends the makefile so that we can build a railroad diagram for the EBNF grammar as well. This is very helpful to detect tiny errors in the grammar.

It works by downloading the Bottlecaps tools in the form of a runnable Java library (`.war` file). This is placed into the folder `_buildtools/railroad/`. The underscore prefixed name, `_buildtools`, is intended to convey that it is itself part of the build process and can be safely deleted.